### PR TITLE
docs: Add detailed setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ This is a Model Context Protocol (MCP) server for Google Forms that allows you t
 
    **a) Using `gcloud` (recommended for local development):**
       - Install the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install).
-      - Log in with your user credentials:
+      - Log in with your user credentials. By default, `gcloud auth application-default login` requests the following scopes: `openid`, `https://www.googleapis.com/auth/userinfo.email`, `https://www.googleapis.com/auth/cloud-platform`, and `https://www.googleapis.com/auth/sqlservice.login`.
+      - For this project, you **must** explicitly provide the necessary scopes for accessing Google Forms and Google Drive by using the `--scopes` flag. These will be requested in addition to the defaults (or will replace them if the gcloud version behavior is to override). The required scopes are:
         ```bash
-        gcloud auth application-default login --scopes=https://www.googleapis.com/auth/forms.body,https://www.googleapis.com/auth/forms.responses.readonly,https://www.googleapis.com/auth/drive.file
+        gcloud auth application-default login --scopes=https://www.googleapis.com/auth/forms.body,https://www.googleapis.com/auth/forms.responses.readonly,https://www.googleapis.com/auth/drive.file,openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform
         ```
-        The `drive.file` scope is necessary for creating new forms, as they are stored in Google Drive.
+        The `drive.file` scope is necessary for creating new forms, as they are stored in Google Drive. The `openid` and `userinfo.email` scopes are commonly included for user authentication context, and `cloud-platform` provides broad access to GCP services which might be useful if the ADC is used for other gcloud operations.
       - This command will open a browser window for you to authenticate. Once done, your ADC will be configured.
       - Ensure your `GOOGLE_PROJECT_ID` is set in your environment (see step 5). The server will use this project.
 
@@ -49,7 +50,7 @@ This is a Model Context Protocol (MCP) server for Google Forms that allows you t
    ```
    Edit `.env` and set:
    - `GOOGLE_PROJECT_ID`: Your Google Cloud project ID. This is required for both ADC methods.
-   - `GOOGLE_APPLICATION_CREDENTIALS`: Path to your service account key file. **Only needed if you are using a service account (option 2b above).** If using `gcloud auth application-default login`, this can be left blank.
+   - `GOOGLE_APPLICATION_CREDENTIALS`: Path to your service account key file.
 
 6. **Build the server:**
    ```


### PR DESCRIPTION
Added detailed instructions to the README.md file on how to:
- Enable the Google Forms API in the Google Cloud Console.
- Configure Application Default Credentials using both gcloud CLI and service accounts.
- Specify the necessary OAuth scopes for the Forms API and Google Drive.