### PR TITLE
I will translate the file `.github/copilot-instructions.md` to English.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,31 +1,31 @@
-# プロジェクト概要
-TypeScriptで書かれたGoogle Forms MCP Server。
+# Project Overview
+A Google Forms MCP Server written in TypeScript.
 
 ## Structure
 ### /src/index.ts
-エントリーポイント。ツールの登録やサーバー起動を行う。
+The entry point. Handles tool registration and server startup.
 
 ### /src/tools
-ツールの定義。classベースで定義される。実装の際は既存の実装をチェックすること。
+Tool definitions. Defined on a class basis. Check existing implementations when implementing.
 
 ### /src/utils/api.ts
-Google Forms APIを操作するためのサービスクラス `GFormService` の実装。すべてのフォーム操作の実装はこのファイルに集約される。
+Implementation of the `GFormService` service class for interacting with the Google Forms API. All form operation implementations are consolidated in this file.
 
-## 実装上の注意
+## Implementation Notes
 ### Google Forms API
-`@googleapis/forms` node.jsクライアントライブラリを使用している。
-Schemaは`/node_modules/@googleapis/forms/build/v1.d.ts`に定義されている。（不明な場合はユーザーに求めること）
+Uses the `@googleapis/forms` node.js client library.
+The schema is defined in `/node_modules/@googleapis/forms/build/v1.d.ts`. (If anything is unclear, ask the user.)
 
-### ツールの定義
-- ツールはclassベースで定義すること。`parameters`はZodによるバリデーションを行う。
-- src/tools/index.tsでの登録を忘れないこと。
+### Tool Definition
+- Tools should be defined on a class basis. `parameters` are validated using Zod.
+- Don't forget to register the tool in src/tools/index.ts.
 
-### 機能拡張のガイドライン
-1. 新しい機能を追加する場合:
-   - 適切なツールクラスを`src/tools/`に作成する
-   - 必要なサービスメソッドを`GFormService`クラスに追加する
-   - `src/tools/index.ts`でツールを登録する
+### Guidelines for Extending Functionality
+1. When adding new features:
+   - Create an appropriate tool class in `src/tools/`.
+   - Add the necessary service methods to the `GFormService` class.
+   - Register the tool in `src/tools/index.ts`.
 
-2. APIの変更に対応する場合:
-   - まず`/node_modules/@googleapis/forms/build/v1.d.ts`で最新のスキーマを確認する
-   - 変更に応じてツールパラメータとサービスメソッドを更新する
+2. When responding to API changes:
+   - First, check the latest schema in `/node_modules/@googleapis/forms/build/v1.d.ts`.
+   - Update tool parameters and service methods according to the changes.


### PR DESCRIPTION
The previous version of the Copilot instructions was in Japanese. This change translates the entire file to English to make it accessible to a wider audience.